### PR TITLE
Fix for infinite redraw on reset

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -161,24 +161,26 @@ const App = (): JSX.Element => {
       }
     });
     const bombs = Math.floor(size ** 2 * percentage);
+    console.log("bombCount:", percentage, difficulty, size, bombs)
     return bombs;
   }, [appState.gameState.options]);
 
   React.useEffect((): void => {
     // Saves bomb count to state if it's a value > 1
-    const bombsState = appState.gameStats.bombs;
-    if (bombsState < 1) {
-      const bombs = calculateBombs();
-      if (bombs && bombs > 1) {
+    const { bombs }: { bombs: number } = appState.gameStats;
+    const { squaresComplete }: { squaresComplete: boolean } = appState.gameState;
+    if (bombs < 1 && squaresComplete) {
+      const bombCount = calculateBombs();
+      if (bombCount && bombCount > 1) {
         appDispatch({
           type: "GAMESTATS_SET_BOMB_COUNT",
           payload: {
-            bombs,
+            bombCount,
           },
         });
       }
     }
-  }, [calculateBombs, appState.gameStats.bombs]);
+  }, [calculateBombs, appState.gameStats, appState.gameState]);
 
   /* --------------------------------------------------------------
     When a square is clicked, all nonbomb, nonhint squares clicked
@@ -400,6 +402,7 @@ const App = (): JSX.Element => {
     const { bombs }: { bombs: number } = appState.gameStats;
     const { squaresComplete }: { squaresComplete: boolean } = appState.gameState;
     const { bombPositions }: { bombPositions: string[] } = appState.gameState;
+    console.log("logging", bombs, squaresComplete, bombPositions.length)
     if (bombs && squaresComplete && !bombPositions.length) {
       const positionArray: string[] = [];
       assignSquaresAsBombs(positionArray, 0);
@@ -431,8 +434,7 @@ const App = (): JSX.Element => {
         },
       });
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [appState.gameState.squaresComplete]);
+  }, [appState.gameState]);
 
   /* ---------------------------------------
     Form submitted, reset the game board

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -161,7 +161,6 @@ const App = (): JSX.Element => {
       }
     });
     const bombs = Math.floor(size ** 2 * percentage);
-    console.log("bombCount:", percentage, difficulty, size, bombs)
     return bombs;
   }, [appState.gameState.options]);
 

--- a/src/components/App/app-reducer.ts
+++ b/src/components/App/app-reducer.ts
@@ -70,7 +70,7 @@ const appReducer = (state: typeof appInit, action: AppAction): AppState => {
         ...state,
         gameStats: {
           ...state.gameStats,
-          bombs: action.payload.bombs,
+          bombs: action.payload.bombCount,
         },
       };
     case "GAMESTATS_UPDATE_TOTALTOREVEAL":

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,7 +160,7 @@ type TotalToReveal = {
 };
 
 type BombCount = {
-  bombs: number;
+  bombCount: number;
 };
 
 type NewGame = {


### PR DESCRIPTION
- Game reset bombCount was overwritten by cleanup due to timing. Added squareComplete dependency to bombCount calc to delay calculation until square map was generated
- In bomb count useEffect, switched to bombs var to enable destructuring, updated reducer, BombCount type, and dispatch to account for change